### PR TITLE
escape param key for sql string

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -93,6 +93,7 @@ var convertParametersInner = function(change, convertString, param) {
               tempParamKey = JSON.stringify(tempParamKey);
             } else {
               tempParamKey = tempParamKey.toString().replace(/"/g, '\\\"');
+              tempParamKey = mysqlRealEscapeParam(tempParamKey);
             }
 
             tempParamKey = tempParamKey.replace(/'/g, "''");
@@ -389,6 +390,33 @@ var uniqueArray = function(a){
     }
   }
   return out;
+}
+
+var mysqlRealEscapeParam = function (param) {
+  if (typeof param != 'string')
+    return param;
+
+  return param.replace(/[\0\x08\x09\x1a\n\r"'\\\%]/g, function (char) {
+    switch (char) {
+      case "\0":
+        return "\\0";
+      case "\x08":
+        return "\\b";
+      case "\x09":
+        return "\\t";
+      case "\x1a":
+        return "\\z";
+      case "\n":
+        return "\\n";
+      case "\r":
+        return "\\r";
+      case "\"":
+      case "'":
+      case "\\":
+      case "%":
+        return "\\" + char;
+    }
+  });
 }
 
 module.exports = {


### PR DESCRIPTION
Fixed that an error occurs if the last character of tempParamKey is \

[Function Reference](https://stackoverflow.com/questions/7744912/making-a-javascript-string-sql-friendly)