### PR TITLE
solve grave accent issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,11 @@
   ],
   "dependencies": {
     "html-parse-stringify": "3.0.1",
-    "sql-formatter": "4.0.2"
+    "sql-formatter": "12.2.1"
   },
   "license": "Apache-2.0",
-  "readmeFilename": "README.md"
+  "readmeFilename": "README.md",
+  "devDependencies": {
+    "mocha": "^10.2.0"
+  }
 }

--- a/test/testgraveaccent.js
+++ b/test/testgraveaccent.js
@@ -1,0 +1,31 @@
+var mybatisMapper = require("../index");
+mybatisMapper.createMapper(["./test/testgraveaccent.xml"]);
+var assert = require("assert");
+
+describe("Unit Tests for Grave accent", function () {
+  it("1) test for Grave accent", function (done) {
+    var format = { language: "sql", indent: " " };
+    var param = {
+      group_name: "manager",
+    };
+    var query = mybatisMapper.getStatement(
+      "testgraveaccent",
+      "findUser",
+      param,
+      format
+    );
+
+    console.log(query);
+    assert.equal(
+      query,
+      `
+SELECT
+  *
+FROM
+  user
+  AND \`group\` = 'manager'
+`.trim()
+    );
+    done();
+  });
+});

--- a/test/testgraveaccent.xml
+++ b/test/testgraveaccent.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="testgraveaccent">  
+  <select id="findUser">
+    SELECT * 
+    FROM user
+    AND `group` = #{group_name}
+  </select>
+</mapper>

--- a/test/testunderline.js
+++ b/test/testunderline.js
@@ -15,11 +15,11 @@ describe("Unit Tests for Issue of mavridiSS", function(){
     assert.equal(query,
 `
 SELECT
- *
+  *
 FROM
- article
+  article
 WHERE
- name = '10'
+  name = '10'
 `.trim())
     done();
   });

--- a/testgraveaccent.xml
+++ b/testgraveaccent.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="testgraveaccent">  
+  <select id="findUser">
+    SELECT * 
+    FROM user
+    AND `group` = #{group_name}
+  </select>
+</mapper>


### PR DESCRIPTION
solve grave accent issue

sql-formatter (4.0.2) add space to grave accent 
sql-formatter (12.2.3) doesn't add space

i change sql-formatter and some test code.

changes
- add grave accent test code
- add grave accent xml code
- change underline test code
- change sql-formatter version
- add dev dependency mocha