### PR TITLE
fix: function scoping of `findMapper` & `replaceCdata`

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ MybatisMapper.prototype.createMapper = function(xmls) {
   }
 };
 
-findMapper = function(children) {
+function findMapper(children) {
   var queryTypes = [ 'sql', 'select', 'insert', 'update', 'delete' ];
 
   if (children.type == 'tag' && children.name == 'mapper') {
@@ -58,7 +58,7 @@ findMapper = function(children) {
   }
 }
 
-replaceCdata = function(rawText) {
+function replaceCdata(rawText) {
   var cdataRegex = new RegExp('(<!\\[CDATA\\[)([\\s\\S]*?)(\\]\\]>)', 'g');
   var matches = rawText.match(cdataRegex);
   


### PR DESCRIPTION
Fix for `"ReferenceError: findMapper is not defined"` when bundling